### PR TITLE
Include KEY_PRESS in masked events in examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ fn main() {
         xcb::WINDOW_CLASS_INPUT_OUTPUT as u16,
         screen.root_visual(), &[
             (xcb::CW_BACK_PIXEL, screen.white_pixel()),
-            (xcb::CW_EVENT_MASK, xcb::EVENT_MASK_EXPOSURE),
+            (xcb::CW_EVENT_MASK,
+             xcb::EVENT_MASK_EXPOSURE | xcb::EVENT_MASK_KEY_PRESS),
         ]
     );
     xcb::map_window(&conn, win);

--- a/examples/drawing.rs
+++ b/examples/drawing.rs
@@ -49,7 +49,8 @@ fn main() {
         xcb::WINDOW_CLASS_INPUT_OUTPUT as u16,
         screen.root_visual(), &[
             (xcb::CW_BACK_PIXEL, screen.white_pixel()),
-            (xcb::CW_EVENT_MASK, xcb::EVENT_MASK_EXPOSURE),
+            (xcb::CW_EVENT_MASK,
+             xcb::EVENT_MASK_EXPOSURE | xcb::EVENT_MASK_KEY_PRESS),
         ]
     );
     xcb::map_window(&conn, win);


### PR DESCRIPTION
Ensure that the key press that is checked for in the
event loop is emitted.