### PR TITLE
Implemented primitive union accessors for struct memebers

### DIFF
--- a/examples/randr_crtc_listen.rs
+++ b/examples/randr_crtc_listen.rs
@@ -1,0 +1,28 @@
+extern crate xcb;
+extern crate libc;
+
+use xcb::randr;
+
+fn main() {
+    let (con, screen_num) = xcb::Connection::connect(None).unwrap();
+    let screen = con.get_setup().roots().nth(screen_num as usize).unwrap();
+
+    let randr_base = con.get_extension_data(&mut randr::id()).unwrap().first_event();
+    let _ = randr::select_input(&con, screen.root(), randr::NOTIFY_MASK_CRTC_CHANGE as u16)
+        .request_check();
+
+    loop {
+        con.flush();
+        let event = con.wait_for_event().unwrap();
+
+        if event.response_type() == randr_base + randr::NOTIFY {
+            let ev: &randr::NotifyEvent = xcb::cast_event(&event);
+            let d = ev.u().cc();
+            println!("received CRTC_NOTIFY event:\n\
+                     \ttimestamp: {}, window: {}, crtc: {}, mode: {}, rotation: {}\n\
+                     \tx: {}, y: {}, width: {}, height: {}",
+                     d.timestamp(), d.window(), d.crtc(), d.mode(), d.rotation(),
+                     d.x(), d.y(), d.width(), d.height());
+        }
+    }
+}

--- a/examples/randr_crtc_listen.rs
+++ b/examples/randr_crtc_listen.rs
@@ -1,5 +1,4 @@
 extern crate xcb;
-extern crate libc;
 
 use xcb::randr;
 

--- a/rs_client.py
+++ b/rs_client.py
@@ -1010,6 +1010,7 @@ def _rs_struct(typeobj):
     _r('')
     _write_doc_brief_desc(_r, typeobj.doc)
     if typeobj.rs_is_pod:
+        _r('#[derive(Copy, Clone)]')
         _r('pub struct %s {', typeobj.rs_type)
         _r('    pub base: %s,', typeobj.ffi_type)
         _r('}')
@@ -1191,7 +1192,7 @@ def _rs_union_accessor(typeobj, field):
             _r('pub fn %s<\'a>(&\'a self) -> %s<\'a> {',
                     field.rs_field_name, field.rs_field_type)
         else:
-            _r('pub fn %s(&self) -> &%s {', field.rs_field_name, field.rs_field_type)
+            _r('pub fn %s(&self) -> %s {', field.rs_field_name, field.rs_field_type)
 
         with _r.indent_block():
             _r('unsafe {')
@@ -1200,7 +1201,7 @@ def _rs_union_accessor(typeobj, field):
                     _r('std::mem::transmute(self)')
                 else:
                     _r('let _ptr = self.data.as_ptr() as *const %s;', field.rs_field_type)
-                    _r('&*_ptr')
+                    _r('*_ptr')
             _r('}')
         _r('}')
 

--- a/rs_client.py
+++ b/rs_client.py
@@ -1198,6 +1198,15 @@ def _rs_union_accessor(typeobj, field):
                     _r('std::mem::transmute(*self)')
             _r('}')
         _r('}')
+        if not (hasattr(field.type, 'struct_ptr') and field.type.struct_ptr):
+            _r('pub fn from_%s(%s: %s) -> %s {', field.rs_field_name,
+                    field.rs_field_name, field.rs_field_type, typeobj.rs_type)
+            with _r.indent_block():
+                _r('unsafe {')
+                with _r.indent_block():
+                        _r('std::mem::transmute(%s)', field.rs_field_name);
+                _r('}')
+            _r('}')
 
 
 

--- a/rs_client.py
+++ b/rs_client.py
@@ -1203,15 +1203,6 @@ def _rs_union_accessor(typeobj, field):
                     _r('_ptr')
             _r('}')
         _r('}')
-        if field.type.rs_is_pod:
-            _r('pub fn from_%s(%s: %s) -> %s {', field.rs_field_name,
-                    field.rs_field_name, field.rs_field_type, typeobj.rs_type)
-            with _r.indent_block():
-                _r('unsafe {')
-                with _r.indent_block():
-                        _r('std::mem::transmute(%s)', field.rs_field_name);
-                _r('}')
-            _r('}')
 
 
 

--- a/rs_client.py
+++ b/rs_client.py
@@ -1191,7 +1191,7 @@ def _rs_union_accessor(typeobj, field):
             _r('pub fn %s<\'a>(&\'a self) -> %s<\'a> {',
                     field.rs_field_name, field.rs_field_type)
         else:
-            _r('pub fn %s(&self) -> %s {', field.rs_field_name, field.rs_field_type)
+            _r('pub fn %s(&self) -> &%s {', field.rs_field_name, field.rs_field_type)
 
         with _r.indent_block():
             _r('unsafe {')
@@ -1199,7 +1199,8 @@ def _rs_union_accessor(typeobj, field):
                 if not field.type.rs_is_pod:
                     _r('std::mem::transmute(self)')
                 else:
-                    _r('std::mem::transmute(*self)')
+                    _r('let _ptr = self.data.as_ptr() as *const %s;', field.rs_field_type)
+                    _r('_ptr')
             _r('}')
         _r('}')
         if field.type.rs_is_pod:

--- a/rs_client.py
+++ b/rs_client.py
@@ -1200,7 +1200,7 @@ def _rs_union_accessor(typeobj, field):
                     _r('std::mem::transmute(self)')
                 else:
                     _r('let _ptr = self.data.as_ptr() as *const %s;', field.rs_field_type)
-                    _r('_ptr')
+                    _r('&*_ptr')
             _r('}')
         _r('}')
 

--- a/rs_client.py
+++ b/rs_client.py
@@ -1019,6 +1019,7 @@ def _rs_struct(typeobj):
 
         _r('pub type %s%s = base::StructPtr<%s%s>;', typeobj.rs_type, lifetime1,
                 lifetime2, typeobj.ffi_type)
+        typeobj.struct_ptr = True
 
 
 def _rs_accessors(typeobj):
@@ -1184,6 +1185,20 @@ def _rs_union_accessor(typeobj, field):
                         field.rs_field_name)
             _r('}')
         _r('}')
+
+
+    elif field.type.is_container:
+        _r('pub fn %s(&self) -> %s {', field.rs_field_name, field.rs_field_type)
+        with _r.indent_block():
+            _r('unsafe {')
+            with _r.indent_block():
+                if hasattr(field.type, 'struct_ptr') and field.type.struct_ptr:
+                    _r('std::mem::transmute(self)')
+                else:
+                    _r('std::mem::transmute(*self)')
+            _r('}')
+        _r('}')
+
 
 
 def _rs_accessor(typeobj, field, disable_pod_acc=False):

--- a/rs_client.py
+++ b/rs_client.py
@@ -1024,12 +1024,10 @@ def _rs_struct(typeobj):
 def _rs_accessors(typeobj):
 
     lifetime = "<'a>" if typeobj.has_lifetime else ""
-    # unions always get an impl lifetime to be sure
-    lifetime2 = "<'a>" if typeobj.is_union else lifetime
 
     _r.section(1)
     _r('')
-    _r('impl%s %s%s {', lifetime2, typeobj.rs_type, lifetime)
+    _r('impl%s %s%s {', lifetime, typeobj.rs_type, lifetime)
     with _r.indent_block():
         if typeobj.rs_is_pod:
             # POD structs have a new method
@@ -1190,7 +1188,7 @@ def _rs_union_accessor(typeobj, field):
 
     elif field.type.is_container:
         if not field.type.rs_is_pod:
-            _r('pub fn %s(&\'a self) -> %s<\'a> {',
+            _r('pub fn %s<\'a>(&\'a self) -> %s<\'a> {',
                     field.rs_field_name, field.rs_field_type)
         else:
             _r('pub fn %s(&self) -> %s {', field.rs_field_name, field.rs_field_type)


### PR DESCRIPTION
We simply monkey-patch the type object for `StructPtr`s and handle
them in a special fashion, as well as generate basic `transmute`-based
accessors for struct members of unions, allowing for a nice solution to #27.

This builds with `--features=debug_all`, but further testing (and possibly more through inspection of the problem) is necessary, as this just cures the symptoms, but isn't really beautiful as a solution. I'd love to hear whether this is the right direction, however.