### PR TITLE
Implement Error/Display for GenericError and ConnError.

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -177,10 +177,8 @@ unsafe impl<T> Sync for Error<T> {}
 
 /// Casts the generic error to the right error. Assumes that the given
 /// error is really the correct type.
-pub fn cast_error<'r, T>(error : &'r GenericError) -> &'r T {
-    // This isn't very safe... but other options incur yet more overhead
-    // that I really don't want to.
-    unsafe { mem::transmute(error) }
+pub unsafe fn cast_error<'r, T>(error : &'r GenericError) -> &'r T {
+    mem::transmute(error)
 }
 
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -171,9 +171,8 @@ impl<T: fmt::Debug> error::Error for Error<T> {
     }
 }
 
-#[cfg(feature="thread")]
+// Error are readonly and can be safely sent and shared with other threads
 unsafe impl<T> Send for Error<T> {}
-#[cfg(feature="thread")]
 unsafe impl<T> Sync for Error<T> {}
 
 /// Casts the generic error to the right error. Assumes that the given


### PR DESCRIPTION
The implementations aren't the smartest or most useful, but I think
they're better than no implementation. With this change, if the 'thread'
feature is enabled, the error types exposed by `xcb` can be used with
`error-chain`.