### PR TITLE
Fixes for xinput support

### DIFF
--- a/rs_client.py
+++ b/rs_client.py
@@ -2264,7 +2264,7 @@ def rs_event(event, nametup):
 
                 new_params.append("%s: %s" % (f.rs_field_name, rs_ftype))
 
-            if event.rs_is_pod:
+            if event.fixed_size():
                 _r('/// Constructs a new %s', event.rs_type)
                 if len(event.opcodes) > 1:
                     _r('/// `response_type` must be set to one of:')


### PR DESCRIPTION
Some fixes in rs_client.py to make xinput wrappers build:
 - Fix accessor functions for not fixed size fields which are not list fields.
 - When converting an Option<...> to a pointer, use null_mut() if we need a mut pointer.
 - Generate ffi accessors for events.
 - Only generate new() functions for POD events.

With these changes, xinput wappers build fine, but I haven't tested them at runtime.