### PR TITLE
Use more lifetimes

### DIFF
--- a/examples/ffi_randr_crtc_info.rs
+++ b/examples/ffi_randr_crtc_info.rs
@@ -14,7 +14,8 @@ fn main() {
         let conn = xcb_connect(ptr::null(), ptr::null_mut());
 
         //Get the first X screen
-        let first_screen = xcb_setup_roots_iterator(xcb_get_setup(conn)).data;
+        let setup = xcb_get_setup(conn);
+        let first_screen = xcb_setup_roots_iterator(&*setup).data;
 
         //Generate ID for the X window
         let window_dummy = xcb_generate_id(conn);

--- a/examples/ffi_screen_info.rs
+++ b/examples/ffi_screen_info.rs
@@ -13,7 +13,7 @@ fn main() {
         if c.is_null() { panic!(); }
 
         let setup = xcb_get_setup(c);
-        let mut iter = xcb_setup_roots_iterator(setup);
+        let mut iter = xcb_setup_roots_iterator(&*setup);
         for _ in 0..screen_num {
             xcb_screen_next(&mut iter as *mut xcb_screen_iterator_t);
         }

--- a/rs_client.py
+++ b/rs_client.py
@@ -823,7 +823,7 @@ def _ffi_accessors_list(typeobj, field):
         _f('pub fn %s (%s)', field.ffi_accessor_fn, params[idx][0])
         _f('        -> *mut %s;', field.ffi_field_type)
 
-    def _may_switch_fn(fn_name, return_type):
+    def _may_switch_fn(fn_name, return_type, nongeneric_iterator=False):
         _f('')
         if switch_obj is not None:
             fn_start = 'pub fn %s (' % fn_name
@@ -832,7 +832,8 @@ def _ffi_accessors_list(typeobj, field):
             _f('%sS: *const %s)', spacing, S_obj.ffi_type)
             _f('        -> %s;', return_type)
         else:
-            _f('pub fn %s (R: *const %s)', fn_name, ffi_type)
+            pointer = "&" if nongeneric_iterator else "*const "
+            _f('pub fn %s (R: %s%s)', fn_name, pointer, ffi_type)
             _f('        -> %s;', return_type)
 
     _may_switch_fn(field.ffi_length_fn, 'c_int')
@@ -840,7 +841,7 @@ def _ffi_accessors_list(typeobj, field):
     if field.type.member.is_simple:
         _may_switch_fn(field.ffi_end_fn, 'xcb_generic_iterator_t')
     else:
-        _may_switch_fn(field.ffi_iterator_fn, field.ffi_iterator_type)
+        _may_switch_fn(field.ffi_iterator_fn, field.ffi_iterator_type, True)
 
 
 
@@ -1310,7 +1311,7 @@ def _rs_accessor(typeobj, field, disable_pod_acc=False):
             with _r.indent_block():
                 _r('unsafe {')
                 with _r.indent_block():
-                    _r('%s(self.ptr)', field.ffi_iterator_fn)
+                    _r('%s(self.borrow())', field.ffi_iterator_fn)
                 _r('}')
             _r('}')
             pass

--- a/src/base.rs
+++ b/src/base.rs
@@ -88,6 +88,19 @@ pub struct StructPtr<'a, T: 'a> {
     phantom: PhantomData<&'a T>
 }
 
+impl<'a, T: 'a> Copy for StructPtr<'a, T> {}
+impl<'a, T: 'a> Clone for StructPtr<'a, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'a, T: 'a> StructPtr<'a, T> {
+    pub unsafe fn borrow(self) -> &'a T {
+        &*self.ptr
+    }
+}
+
 
 /// `Event` wraps a pointer to `xcb_*_event_t`
 /// this pointer will be freed when the `Event` goes out of scope
@@ -229,6 +242,11 @@ impl<T> Drop for Reply<T> {
     }
 }
 
+impl<T> Reply<T> {
+    pub unsafe fn borrow<'a>(&'a self) -> &'a T {
+        &*self.ptr
+    }
+}
 #[cfg(feature="thread")]
 unsafe impl<T> Send for Reply<T> {}
 #[cfg(feature="thread")]


### PR DESCRIPTION
Currently this crate has FFI functions which have no lifetimes in the arguments but a lifetime in the return type.

This currently compiles, but is a bug -- you can't do the same for non-FFI functions, for example.

Nor does it make sense, such a function will return an unbounded lifetime.

On the latest nightly [this causes ICEs](https://github.com/rust-lang/rust/issues/43567), and one of the possible fixes is to turn this into a hard error as we do for non FFI functions.


I added some lifetimes so that it will elide correctly. It would be possible to implement Deref for StructPtr and Base, however currently they have public pointer fields so it is not possible to dereference these safely. Instead I added an unsafe borrow() method that cleanly gives you the contents as a pointer with the right lifetimes. I can clean this up further if you'd like.