### PR TITLE
Make source generation deterministic

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -68,6 +68,7 @@ fn main() {
                     .arg(&r_client)
                     .arg("-o").arg(&src_dir)
                     .arg(&xml_file)
+                    .env("PYTHONHASHSEED", "0")
                     .status());
             if !status.success() {
                 panic!("processing of {} returned non-zero ({})",

--- a/rs_client.py
+++ b/rs_client.py
@@ -34,7 +34,6 @@ Usage: ./rs_client.py -o src xml/xproto.xml
 
 import sys
 import os
-import time
 import re
 
 
@@ -201,8 +200,8 @@ def rs_open(module):
 
     _r.section(0)
     _f.section(0)
-    _rf('// Generated automatically from %s by rs_client.py on %s.',
-            _ns.file, time.strftime('%c'))
+    _rf('// Generated automatically from %s by rs_client.py version %s.',
+            _ns.file, os.getenv('CARGO_PKG_VERSION', 'undefined'))
     _rf('// Do not edit!')
     _rf('')
 


### PR DESCRIPTION
This patch enables vendoring of the crate.

The issue is that cargo-vendor stores checksums of all crate's source files after the first build. Unfortunately this crate generates slightly different sources every time, which makes it hard to vendor: cargo's checksum test fails on build. There is currently no way to make cargo-vendor ignore some of the source files when calculating checksums.

This small patch makes `rs_client.py` always generate identical source code for a single crate version:

1. Timestamp at the top of generated files is replaced with version tag.
2. Iteration of Python dicts and sets is made deterministic by setting PYTHONHASHSEED envvar.