### PR TITLE
Add Connection.into_raw_conn

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -494,6 +494,13 @@ impl Connection {
         self.c
     }
 
+    /// Consumes this object, returning the inner ffi `xcb_connection_t` pointer
+    pub fn into_raw_conn(self) -> *mut xcb_connection_t {
+        let c = self.c;
+        mem::forget(self);
+        c
+    }
+
     /// Returns the inner ffi `xlib::Display` pointer.
     #[cfg(feature="xlib_xcb")]
     pub fn get_raw_dpy(&self) -> *mut xlib::Display {


### PR DESCRIPTION
When using rust-xcb to access an already existing xcb connection (for example, one from glutin), a way to avoid calling the destructor was needed. This pattern is similar to IntoRawFd from the standard library.