### PR TITLE
Improve missing python error in build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -64,12 +64,13 @@ fn main() {
 
         if ref_mtime > src_file_mtime || ref_mtime > ffi_file_mtime {
 
-            let status = try!(Command::new("python3")
+            let status = Command::new("python3")
                     .arg(&r_client)
                     .arg("-o").arg(&src_dir)
                     .arg(&xml_file)
                     .env("PYTHONHASHSEED", "0")
-                    .status());
+                    .status()
+                    .expect("Unable to find build dependency python3");
             if !status.success() {
                 panic!("processing of {} returned non-zero ({})",
                     xml_file.display(), status.code().unwrap());


### PR DESCRIPTION
The build.rs file requires python3 to execute, but when it is missing it
just prints a "No such file or directory" error.

To make this dependency error more clear, an `expect` has been added
that informs the user that the build dependency python3 is missing.

This fixes #49.