### PR TITLE
Implement Drop on Cookies

### DIFF
--- a/examples/randr_crtc_info.rs
+++ b/examples/randr_crtc_info.rs
@@ -27,7 +27,7 @@ fn main() {
         crtc_cookies.push(randr::get_crtc_info(&conn, *crtc, 0));
     }
 
-    for (i, crtc_cookie) in crtc_cookies.iter().enumerate() {
+    for (i, crtc_cookie) in crtc_cookies.into_iter().enumerate() {
         if let Ok(reply) = crtc_cookie.get_reply() {
             if i != 0 { println!(""); }
             println!("CRTC[{}] INFO:", i);

--- a/src/base.rs
+++ b/src/base.rs
@@ -227,9 +227,9 @@ impl<'a, T: Copy + CookieSeq> Drop for Cookie<'a, T> {
 }
 
 #[cfg(feature="thread")]
-unsafe impl<'a, T: Copy> Send for Cookie<'a, T> {}
+unsafe impl<'a, T: Copy + CookieSeq> Send for Cookie<'a, T> {}
 #[cfg(feature="thread")]
-unsafe impl<'a, T: Copy> Sync for Cookie<'a, T> {}
+unsafe impl<'a, T: Copy + CookieSeq> Sync for Cookie<'a, T> {}
 
 
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -186,26 +186,43 @@ pub unsafe fn cast_error<'r, T>(error : &'r GenericError) -> &'r T {
 /// wraps a cookie as returned by a request function.
 /// Instantiations of `Cookie` that are not `VoidCookie`
 /// should provide a `get_reply` method to return a `Reply`
-pub struct Cookie<'a, T: Copy> {
+pub struct Cookie<'a, T: Copy + CookieSeq> {
     pub cookie: T,
     pub conn: &'a Connection,
-    pub checked: bool
+    pub checked: bool,
 }
 
 pub type VoidCookie<'a> = Cookie<'a, xcb_void_cookie_t>;
 
 impl<'a> VoidCookie<'a> {
-    pub fn request_check(&self) -> Result<(), GenericError> {
+    pub fn request_check(self) -> Result<(), GenericError> {
         unsafe {
-            let c : xcb_void_cookie_t = mem::transmute(self.cookie);
+            let c: xcb_void_cookie_t = mem::transmute(self.cookie);
             let err = xcb_request_check(self.conn.get_raw_conn(), c);
 
+            std::mem::forget(self);
             if err.is_null() {
                 Ok(())
             } else {
-                Err(GenericError{ ptr: err })
+                Err(GenericError { ptr: err })
             }
         }
+    }
+}
+
+impl CookieSeq for xcb_void_cookie_t {
+    fn sequence(&self) -> libc::c_uint {
+        self.sequence
+    }
+}
+
+pub trait CookieSeq {
+    fn sequence(&self) -> libc::c_uint;
+}
+
+impl<'a, T: Copy + CookieSeq> Drop for Cookie<'a, T> {
+    fn drop(&mut self) {
+        unsafe { xcb_discard_reply(self.conn.get_raw_conn(), self.cookie.sequence()) };
     }
 }
 

--- a/src/ffi/base.rs
+++ b/src/ffi/base.rs
@@ -144,7 +144,7 @@ impl Clone for xcb_generic_error_t {
 #[repr(C)]
 pub struct xcb_void_cookie_t {
     /// sequence number
-    pub sequence: c_int
+    pub sequence: c_uint
 }
 
 
@@ -484,4 +484,3 @@ extern {
             -> u32;
 
 }
-


### PR DESCRIPTION
Apparently people order cookies and don't want to eat them. But```rust-xcb``` does not provide a way to call ```xcb_discard_reply``` because ```sequence``` field is not public. This PR goes all the way to clean-up cookies when they go out of scope. 

Fixes #57.