### PR TITLE
xcb::Connection::connect -> Fix use after free on displayname

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -563,13 +563,21 @@ impl Connection {
     /// Err(ConnError) in case of error. If no screen is preferred, the second
     /// member of the tuple is set to 0.
     pub fn connect(displayname: Option<&str>) -> ConnResult<(Connection, i32)> {
+        let mut screen_num : c_int = 0;
+        let displayname = displayname.map(|s| CString::new(s).unwrap());
         unsafe {
-            let display = displayname.map(|s| CString::new(s).unwrap());
-            let mut screen_num : c_int = 0;
-            let cconn = xcb_connect(
-                display.map_or(null(), |s| s.as_ptr()),
+            let cconn = if let Some(display) = displayname {
+                xcb_connect(
+                    display.as_ptr(),
+                    &mut screen_num
+                )
+            } else {
+                xcb_connect(
+                null(),
                 &mut screen_num
-            );
+               )
+            };
+
 
             // xcb doc says that a valid object is always returned
             // so we simply assert without handling this in the return
@@ -625,16 +633,24 @@ impl Connection {
     /// Connects to the X server specified by displayname, using the
     /// authorization auth.
     /// The second member of the returned tuple is the preferred screen, or 0
-    pub fn connect_with_auth_info(display: Option<&str>, auth_info: &AuthInfo)
+    pub fn connect_with_auth_info(displayname: Option<&str>, auth_info: &AuthInfo)
     -> ConnResult<(Connection, i32)> {
         unsafe {
-            let display = display.map(|s| CString::new(s).unwrap());
             let mut screen_num : c_int = 0;
-            let cconn = xcb_connect_to_display_with_auth_info(
-                display.map_or(null(), |s| s.as_ptr()),
-                mem::transmute(auth_info),
-                &mut screen_num
-            );
+            let displayname = displayname.map(|s| CString::new(s).unwrap());
+            let cconn = if let Some(display) = displayname {
+                xcb_connect_to_display_with_auth_info(
+                    display.as_ptr(),
+                    mem::transmute(auth_info),
+                    &mut screen_num
+                )
+            } else {
+                xcb_connect_to_display_with_auth_info(
+                    null(),
+                    mem::transmute(auth_info),
+                    &mut screen_num
+                )
+            };
 
             // xcb doc says that a valid object is always returned
             // so we simply assert without handling this in the return


### PR DESCRIPTION
when supplying a ```displayname``` to get  connection to xcb, ```CString``` goes out of scope when ```map_or``` returns... 