### PR TITLE
Use `ElementTree` instead of `cElementTree`

### DIFF
--- a/xcbgen/matcher.py
+++ b/xcbgen/matcher.py
@@ -7,7 +7,7 @@ we do not create a new type object, we just record the existing one under a new 
 '''
 
 from os.path import join
-from xml.etree.cElementTree import parse
+from xml.etree.ElementTree import parse
 
 from xcbgen.xtypes import *
 

--- a/xcbgen/state.py
+++ b/xcbgen/state.py
@@ -2,7 +2,7 @@
 This module contains the namespace class and the singleton module class.
 '''
 from os.path import dirname, basename
-from xml.etree.cElementTree import parse
+from xml.etree.ElementTree import parse
 
 from xcbgen import matcher
 from xcbgen.error import *


### PR DESCRIPTION
`cElementTree` has been deprecated since Python 3.3; `ElementTree` will use a fast implementation whenever available.

`cElementTree` is actually removed as of Python 3.9 beta 1, and on Python 3.8 it's an alias to `ElementTree`.

See https://docs.python.org/3.8/library/xml.etree.elementtree.html

Signed-off-by: Michel Alexandre Salim <michel@michel-slm.name>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rtbo/rust-xcb/87)
<!-- Reviewable:end -->
