### PR TITLE
Make the library build on FreeBSD

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -89,4 +89,6 @@ fn main() {
     println!("cargo:rerun-if-changed={}", &xml_dir.display());
     println!("cargo:rerun-if-changed={}", &xcbgen_dir.display());
 
+    #[cfg(target_os = "freebsd")]
+    println!("cargo:rustc-link-search=/usr/local/lib");
 }


### PR DESCRIPTION
FreeBSD does not have the needed libraries
in the default search path.

This patch adds the needed folder to the
search path of `rustc` on FreeBSD.